### PR TITLE
Extend transceiver for multichain support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "@prb/foundry-template",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.1",
+        "@openzeppelin/contracts-upgradeable": "^4.8.1",
         "@risc0/ethereum": "github:risc0/risc0-ethereum#v2.2.0",
         "wormhole-ntt": "github:wormhole-foundation/native-token-transfers#f106797359ba4a6743b9b4eeb06ee5415780df86",
         "wormhole-sdk": "github:wormhole-foundation/wormhole-solidity-sdk#v0.1.0",
@@ -23,6 +24,8 @@
     "@babel/highlight": ["@babel/highlight@7.23.4", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.22.20", "chalk": "^2.4.2", "js-tokens": "^4.0.0" } }, "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A=="],
 
     "@openzeppelin/contracts": ["@openzeppelin/contracts@4.9.6", "", {}, "sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA=="],
+
+    "@openzeppelin/contracts-upgradeable": ["@openzeppelin/contracts-upgradeable@4.9.6", "", {}, "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA=="],
 
     "@risc0/ethereum": ["risc0-ethereum@github:risc0/risc0-ethereum#382d76a", {}, "risc0-risc0-ethereum-382d76a"],
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_sol_types::sol;
 use risc0_steel::{Commitment, ethereum::EthEvmInput};
 
@@ -20,7 +20,7 @@ use risc0_steel::{Commitment, ethereum::EthEvmInput};
 pub struct GuestInput {
     pub commitment: EthEvmInput,
     pub encoded_message: Bytes,
-    pub contract_addr: Address,
+    pub contract_addr: B256,
 }
 
 impl GuestInput {
@@ -55,6 +55,22 @@ sol! {
         bytes encodedMessage;
 
         // The contract that emitted the message event
-        address emitterContract;
+        bytes32 emitterContract;
     }
+}
+
+/// Converts a Wormhole format B256 address to an Ethereum Address.
+pub fn from_wormhole_address(wormhole_addr: B256) -> Address {
+    // Extract the last 20 bytes from the 32-byte B256
+    // This reverses the Solidity conversion: bytes32(uint256(uint160(address)))
+    let bytes = wormhole_addr.as_slice();
+    let addr_bytes = &bytes[12..]; // Skip first 12 bytes, take last 20
+    Address::from_slice(addr_bytes)
+}
+
+/// Converts a Ethereum Address to a Wormhole format address
+pub fn to_wormhole_address(address: Address) -> B256 {
+    let mut bytes = [0u8; 32];
+    bytes[12..].copy_from_slice(address.as_slice());
+    B256::from(bytes)
 }

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -17,7 +17,7 @@ use alloy::rpc::types::TransactionReceipt;
 use alloy_primitives::{Address, TxHash};
 use alloy_sol_types::SolEvent;
 use anyhow::{Context, Result, ensure};
-use common::{GuestInput, IBoundlessTransceiver};
+use common::{GuestInput, IBoundlessTransceiver, to_wormhole_address};
 use risc0_steel::ethereum::ETH_MAINNET_CHAIN_SPEC;
 use risc0_steel::{
     Event, alloy::transports::http::reqwest::Url, ethereum::EthEvmEnv, host::BlockNumberOrTag,
@@ -92,7 +92,7 @@ pub async fn build_input(
 
     let input = GuestInput {
         commitment: evm_input,
-        contract_addr,
+        contract_addr: to_wormhole_address(contract_addr),
         encoded_message,
     };
 

--- a/crates/zkvm/guest/src/main.rs
+++ b/crates/zkvm/guest/src/main.rs
@@ -14,7 +14,7 @@
 #![no_main]
 
 use alloy_sol_types::SolValue;
-use common::{GuestInput, IBoundlessTransceiver, Journal};
+use common::{from_wormhole_address, GuestInput, IBoundlessTransceiver, Journal};
 use risc0_steel::{ethereum::ETH_MAINNET_CHAIN_SPEC, Event};
 use risc0_zkvm::guest::env;
 
@@ -29,7 +29,9 @@ fn main() {
 
     // Query the `SendTransceiverMessage` events of the contract and ensure it contains the expected message digest
     let event = Event::new::<IBoundlessTransceiver::SendTransceiverMessage>(&env);
-    let logs = &event.address(input.contract_addr).query();
+    let logs = &event
+        .address(from_wormhole_address(input.contract_addr))
+        .query();
     assert!(
         logs.iter()
             .any(|log| log.encodedMessage == input.encoded_message),

--- a/crates/zkvm/src/lib.rs
+++ b/crates/zkvm/src/lib.rs
@@ -7,7 +7,7 @@ mod tests {
         dyn_abi::SolType, network::EthereumWallet, node_bindings::Anvil, primitives::Bytes,
         providers::ProviderBuilder, signers::local::PrivateKeySigner, sol,
     };
-    use common::{GuestInput, Journal};
+    use common::{from_wormhole_address, to_wormhole_address, GuestInput, Journal};
     use risc0_steel::{
         ethereum::{EthEvmEnv, ETH_MAINNET_CHAIN_SPEC},
         Event,
@@ -90,7 +90,7 @@ mod tests {
 
             let input = GuestInput {
                 commitment: evm_input,
-                contract_addr: contract.address().clone(),
+                contract_addr: to_wormhole_address(contract.address().clone()),
                 encoded_message: expected_message(),
             };
 
@@ -112,7 +112,10 @@ mod tests {
                         panic!("Test case {i}: Expected error: {expected}, but got success");
                     }
                     let journal = Journal::abi_decode(&info.journal.bytes)?;
-                    assert_eq!(journal.emitterContract, *contract.address());
+                    assert_eq!(
+                        from_wormhole_address(journal.emitterContract),
+                        *contract.address()
+                    );
                     assert_eq!(journal.encodedMessage, expected_message());
                 }
                 Err(e) => {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
 	},
 	"dependencies": {
 		"@openzeppelin/contracts": "^4.8.1",
+		"@openzeppelin/contracts-upgradeable": "^4.8.1",
 		"@risc0/ethereum": "github:risc0/risc0-ethereum#v2.2.0",
 		"wormhole-sdk": "github:wormhole-foundation/wormhole-solidity-sdk#v0.1.0",
-    "wormhole-ntt": "github:wormhole-foundation/native-token-transfers#f106797359ba4a6743b9b4eeb06ee5415780df86"
+		"wormhole-ntt": "github:wormhole-foundation/native-token-transfers#f106797359ba4a6743b9b4eeb06ee5415780df86"
 	},
 	"devDependencies": {
 		"forge-std": "github:foundry-rs/forge-std#v1.9.7",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 openzeppelin-contracts/=node_modules/@openzeppelin/
 @risc0/contracts/=node_modules/@risc0/ethereum/contracts/src/
 forge-std/=node_modules/forge-std/src/

--- a/src/BlockRootOracle.sol
+++ b/src/BlockRootOracle.sol
@@ -163,12 +163,10 @@ contract BlockRootOracle is AccessControl, ICommitmentValidator {
         _transition(journal);
     }
 
-    /// @notice Retrieves the beacon block root for a given slot with confirmation level validation
-    /// @dev Returns the block root and validation status based on confirmation level requirements
-    /// @param slot The beacon chain slot to look up
-    /// @param confirmationLevel The level of confirmations required for validation
-    /// @return root The beacon block root for the given slot
-    /// @return valid Whether the root is valid based on confirmation level requirements
+    /// @notice the root associated with the provided `slot`. If the confirmation level isn't met or the root is not
+    /// set, `valid` will be false
+    /// @param slot the beacon chain slot to look up
+    /// @param confirmationLevel the level of confirmations required for `valid` to be `true`
     function blockRoot(uint64 slot, uint16 confirmationLevel) public view returns (bytes32 root, bool valid) {
         root = roots[slot];
         if (root == UNDEFINED_ROOT) {
@@ -281,11 +279,7 @@ contract BlockRootOracle is AccessControl, ICommitmentValidator {
         return remainder == targetLevel;
     }
 
-    /// @notice Validates a Steel commitment. Only supports v2 commitments which identify the beacon block root by its
-    /// slot
-    /// @param commitment The commitment to validate
-    /// @param confirmationLevel  A flag indicating required level of confirmation the block root must meet
-    /// @return True if the commitment is valid
+    /// @inheritdoc ICommitmentValidator
     function validateCommitment(
         Steel.Commitment memory commitment,
         uint16 confirmationLevel
@@ -294,12 +288,12 @@ contract BlockRootOracle is AccessControl, ICommitmentValidator {
         view
         returns (bool)
     {
-        (uint240 blockID, uint16 version) = SteelEncoding.decodeVersionedID(commitment.id);
+        (uint240 blockId, uint16 version) = SteelEncoding.decodeVersionedID(commitment.id);
         if (version != 2) {
             revert Steel.InvalidCommitmentVersion();
         }
 
-        return validateReceiverCommitment(SafeCast.toUint64(blockID), commitment.digest, confirmationLevel);
+        return validateReceiverCommitment(SafeCast.toUint64(blockId), commitment.digest, confirmationLevel);
     }
 
     /// @notice Validates commitment against the BoundlessReceiver contract

--- a/src/BlockRootOracle.sol
+++ b/src/BlockRootOracle.sol
@@ -9,12 +9,13 @@ import { toWormholeFormat } from "wormhole-solidity-sdk/Utils.sol";
 import { Beacon } from "./lib/Beacon.sol";
 import { Steel, Encoding as SteelEncoding } from "@risc0/contracts/steel/Steel.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { ICommitmentValidator } from "./interfaces/ICommitmentValidator.sol";
 
 uint16 constant BOUNDLESS_FLAG = 0;
 uint16 constant WORMHOLE_FLAG = 1;
 uint16 constant TWO_OF_TWO_FLAG = uint16((1 << BOUNDLESS_FLAG) | (1 << WORMHOLE_FLAG));
 
-contract BlockRootOracle is AccessControl {
+contract BlockRootOracle is AccessControl, ICommitmentValidator {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 constant UNDEFINED_ROOT = bytes32(0);
 

--- a/src/interfaces/ICommitmentValidator.sol
+++ b/src/interfaces/ICommitmentValidator.sol
@@ -4,17 +4,7 @@ pragma solidity ^0.8.0;
 
 import { Steel } from "@risc0/contracts/steel/Steel.sol";
 
-interface IBlockRootOracle {
-    /**
-     * @notice the root associated with the provided `slot`. If the confirmation level isn't met or the root is not
-     * set, `valid` will be false
-     *
-     *
-     * @param slot the beacon chain slot to look up
-     * @param confirmationLevel the level of confirmations required for `valid` to be `true`
-     */
-    function blockRoot(uint64 slot, uint16 confirmationLevel) external view returns (bytes32 root, bool valid);
-
+interface ICommitmentValidator {
     // @notice Validates a Steel commitment. Only supports v2 commitments which identify the beacon block root by its
     /// slot
     /// @param commitment The commitment to validate

--- a/test/BoundlessTransceiver.sol
+++ b/test/BoundlessTransceiver.sol
@@ -54,8 +54,9 @@ contract BoundlessTransceiverTest is Test {
         receiver = new DummyReceiver();
 
         transceiver = new BoundlessTransceiver(
-            address(manager), address(verifier), NTT_MESSAGE_INCLUSION_ID
+            address(manager), address(verifier), NTT_MESSAGE_INCLUSION_ID, address(OWNER), address(OWNER)
         );
+        vm.prank(OWNER);
         transceiver.setCommitmentValidator(CHAIN_ID_B, receiver);
         vm.prank(OWNER);
         manager.setTransceiver(address(transceiver));

--- a/test/BoundlessTransceiver.sol
+++ b/test/BoundlessTransceiver.sol
@@ -57,7 +57,7 @@ contract BoundlessTransceiverTest is Test {
             address(manager), address(verifier), NTT_MESSAGE_INCLUSION_ID, address(OWNER), address(OWNER)
         );
         vm.prank(OWNER);
-        transceiver.setCommitmentValidator(CHAIN_ID_B, receiver);
+        transceiver.setAuthorizedSource(CHAIN_ID_B, bytes32(0), receiver);
         vm.prank(OWNER);
         manager.setTransceiver(address(transceiver));
     }
@@ -150,7 +150,7 @@ contract BoundlessTransceiverTest is Test {
             BoundlessTransceiver.Journal({
                 commitment: Steel.Commitment(Encoding.encodeVersionedID(consensusSlot, 2), blockRoot, bytes32(0x0)),
                 encodedMessage: encodedTransceiverMessage,
-                emitterContract: address(0)
+                emitterContract: bytes32(0)
             })
         );
 
@@ -202,7 +202,7 @@ contract BoundlessTransceiverTest is Test {
             BoundlessTransceiver.Journal({
                 commitment: Steel.Commitment(Encoding.encodeVersionedID(consensusSlot, 2), blockRoot, bytes32(0x0)),
                 encodedMessage: encodedTransceiverMessage,
-                emitterContract: address(0)
+                emitterContract: bytes32(0)
             })
         );
 

--- a/test/BoundlessTransceiver.t.sol
+++ b/test/BoundlessTransceiver.t.sol
@@ -12,13 +12,13 @@ import { Receipt as RiscZeroReceipt } from "@risc0/contracts/IRiscZeroVerifier.s
 import { RiscZeroMockVerifier } from "@risc0/contracts/test/RiscZeroMockVerifier.sol";
 import { Steel, Encoding } from "@risc0/contracts/steel/Steel.sol";
 import { toWormholeFormat } from "wormhole-solidity-sdk/Utils.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import { DummyTokenMintAndBurn } from "./mocks/DummyToken.sol";
 import { DummyReceiver } from "./mocks/DummyReceiver.sol";
 
 import "forge-std/console.sol";
 import "forge-std/Test.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
 
 contract BoundlessTransceiverTest is Test {
     address constant OWNER = address(1004);
@@ -39,6 +39,7 @@ contract BoundlessTransceiverTest is Test {
     BoundlessTransceiver transceiver;
 
     function setUp() public {
+        vm.startPrank(OWNER);
         token = new DummyTokenMintAndBurn();
 
         address managerImplementation = address(
@@ -46,20 +47,19 @@ contract BoundlessTransceiverTest is Test {
                 address(token), IManagerBase.Mode.LOCKING, CHAIN_ID_A, RATE_LIMIT_DURATION, SKIP_RATE_LIMITING
             )
         );
-        manager = NttManager(address(new ERC1967Proxy(managerImplementation, "")));
-        manager.initialize();
-        manager.transferOwnership(OWNER);
 
         verifier = new RiscZeroMockVerifier(MOCK_SELECTOR);
         receiver = new DummyReceiver();
 
-        transceiver = new BoundlessTransceiver(
-            address(manager), address(verifier), NTT_MESSAGE_INCLUSION_ID, address(OWNER), address(OWNER)
-        );
-        vm.prank(OWNER);
-        transceiver.setAuthorizedSource(CHAIN_ID_B, bytes32(0), receiver);
-        vm.prank(OWNER);
+        manager = NttManager(address(new ERC1967Proxy(managerImplementation, "")));
+        manager.initialize();
+        BoundlessTransceiver implementation = new BoundlessTransceiver(address(manager));
+
+        bytes memory initializer = abi.encodeCall(BoundlessTransceiver.initialize, (address(verifier)));
+        transceiver = BoundlessTransceiver(address(new ERC1967Proxy(address(implementation), initializer)));
+        transceiver.setAuthorizedSource(CHAIN_ID_B, bytes32(0), address(receiver), NTT_MESSAGE_INCLUSION_ID);
         manager.setTransceiver(address(transceiver));
+        vm.stopPrank();
     }
 
     // Testing sending a message from CHAIN_A
@@ -154,7 +154,7 @@ contract BoundlessTransceiverTest is Test {
             })
         );
 
-        vm.expectRevert("Unsupported source chain");
+        vm.expectRevert(abi.encodeWithSelector(BoundlessTransceiver.UnsupportedSourceChain.selector, CHAIN_ID_C));
         transceiver.receiveMessage(journalBytes, bytes("dummy seal"));
     }
 
@@ -211,7 +211,7 @@ contract BoundlessTransceiverTest is Test {
         // create a mock proof
         RiscZeroReceipt memory receipt = verifier.mockProve(NTT_MESSAGE_INCLUSION_ID, sha256(journalBytes));
 
-        vm.expectRevert("Invalid commitment");
+        vm.expectRevert(BoundlessTransceiver.InvalidCommitment.selector);
         transceiver.receiveMessage(journalBytes, receipt.seal);
 
         // Set the expected block root in the dummy receiver

--- a/test/mocks/DummyReceiver.sol
+++ b/test/mocks/DummyReceiver.sol
@@ -2,11 +2,11 @@
 
 pragma solidity >=0.8.8 <0.9.0;
 
-import { IBlockRootOracle } from "../../src/interfaces/IBlockRootOracle.sol";
+import { ICommitmentValidator } from "../../src/interfaces/ICommitmentValidator.sol";
 import { Steel, Encoding as SteelEncoding } from "@risc0/contracts/steel/Steel.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-contract DummyReceiver is IBlockRootOracle {
+contract DummyReceiver is ICommitmentValidator {
     mapping(uint64 slot => bytes32 blockRoot) private roots;
 
     function setBlockRoot(uint64 slot, bytes32 root) public {


### PR DESCRIPTION
We will need to support more than just Ethereum -> Other native transfers.

This begins adding the features to the transceiver to support multichain deployments, preempting the ability to generate a source of trusted block roots and even inclusion ZK proofs