### PR TITLE
Make public the BlockRootOracle current state

### DIFF
--- a/src/BlockRootOracle.sol
+++ b/src/BlockRootOracle.sol
@@ -39,7 +39,7 @@ contract BlockRootOracle is AccessControl, ICommitmentValidator {
 
     /// @notice The current consensus state of the beacon chain
     /// @dev Updated atomically through state transitions to ensure consistency
-    ConsensusState private currentState;
+    ConsensusState public currentState;
 
     bytes32 public imageID;
 


### PR DESCRIPTION
This makes it much easier to query the current state of the contract which can then be used to query for the required proofs for updates